### PR TITLE
Pull forward safemem to 0.2 and memchr to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buf_redux"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 
 description = "Drop-in replacements for buffered I/O in `std::io` with extra features."
@@ -14,8 +14,8 @@ repository = "https://github.com/abonander/buf_redux"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-safemem = "0.1"
-memchr = "0.1"
+safemem = "0.2"
+memchr = "1.0"
 
 [features]
 nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,7 +803,7 @@ impl Buffer {
 
         let copy_amt = self.buffered();
         // Guaranteed lowering to memmove.
-        safemem::copy(self.buf.get_mut(), self.pos, 0, copy_amt);
+        safemem::copy_over(self.buf.get_mut(), self.pos, 0, copy_amt);
 
         self.end -= self.pos;
         self.pos = 0;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -34,10 +34,6 @@ mod impl_ {
             self.buf.capacity()
         }
 
-        pub fn get(&self) -> &[u8] {
-            &self.buf
-        }
-
         pub fn get_mut(&mut self) -> &mut [u8] {
             &mut self.buf
         }


### PR DESCRIPTION
Noticed and fixed a quick warn[unused code] while at it.
I believe this only warrants a patch update since it's an internal dependency (not changing external contract).