### PR TITLE
fix: ensure tests pass when using no-default-features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,17 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+
+script:
+ - |
+   if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then
+       cargo build --verbose $ARGS --features "nightly";
+       cargo test --verbose --features "nightly";
+       cargo doc --verbose --features "nightly";
+   fi
+ - cargo build --verbose
+ - cargo test --verbose
+ - cargo doc --verbose
+ - cargo build --verbose --no-default-features
+ - cargo test --verbose --no-default-features
+ - cargo doc --verbose --no-default-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,7 @@ impl<W: Write> BufWriter<W> {
     /// enabled. The default capacity will differ between Windows and Unix-derivative targets.
     /// See [`Buffer::new_ringbuf()`](Buffer::new_ringbuf)
     /// or [the crate root docs](index.html#ringbuffers--slice-deque-feature) for more info.
+    #[cfg(feature = "slice-deque")]
     pub fn new_ringbuf(inner: W) -> Self {
         Self::with_buffer(Buffer::new_ringbuf(), inner)
     }
@@ -544,6 +545,7 @@ impl<W: Write> BufWriter<W> {
     /// enabled. The capacity will be rounded up to the minimum size for the target platform.
     /// See [`Buffer::with_capacity_ringbuf()`](Buffer::with_capacity_ringbuf)
     /// or [the crate root docs](index.html#ringbuffers--slice-deque-feature) for more info.
+    #[cfg(feature = "slice-deque")]
     pub fn with_capacity_ringbuf(cap: usize, inner: W) -> Self {
         Self::with_buffer(Buffer::with_capacity_ringbuf(cap), inner)
     }
@@ -749,11 +751,13 @@ impl<W: Write> LineWriter<W> {
     }
 
     /// Wrap `inner` with the default buffer capacity using a ringbuffer.
+    #[cfg(feature = "slice-deque")]
     pub fn new_ringbuf(inner: W) -> Self {
         Self::with_buffer(Buffer::new_ringbuf(), inner)
     }
 
     /// Wrap `inner` with the given buffer capacity using a ringbuffer.
+    #[cfg(feature = "slice-deque")]
     pub fn with_capacity_ringbuf(cap: usize, inner: W) -> Self {
         Self::with_buffer(Buffer::with_capacity_ringbuf(cap), inner)
     }


### PR DESCRIPTION
The tests were failing for me when running with `--no-default-features`. This makes them work again 