### PR TITLE
Bump slice-deque version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ memchr = "2.0"
 
 # `slice_deque` is only supported on platforms with virtual memory
 [target.'cfg(any(unix, windows))'.dependencies.slice-deque]
-version = "0.1"
+version = "0.2"
 optional = true
 
 [features]


### PR DESCRIPTION
0.1 is vulnerable to https://rustsec.org/advisories/RUSTSEC-2019-0002.html