### PR TITLE
Support stacked borrows in BufWriter::into_inner_

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,8 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::io::prelude::*;
 use std::io::SeekFrom;
-use std::{cmp, error, fmt, io, mem, ptr};
+use std::mem::ManuallyDrop;
+use std::{cmp, error, fmt, io, ptr};
 
 #[cfg(all(feature = "nightly", test))]
 mod benches;
@@ -629,11 +630,11 @@ impl<W: Write, P> BufWriter<W, P> {
 
     // copy the fields out and forget `self` to avoid dropping twice
     fn into_inner_(self) -> (W, Buffer) {
+        let s = ManuallyDrop::new(self);
         unsafe {
             // safe because we immediately forget `self`
-            let inner = ptr::read(&self.inner);
-            let buf = ptr::read(&self.buf);
-            mem::forget(self);
+            let inner = ptr::read(&s.inner);
+            let buf = ptr::read(&s.buf);
             (inner, buf)
         }
     }


### PR DESCRIPTION
This avoids errors in miri due to mem::forget currently behaving like a regular function call.

Also see https://github.com/rust-lang/rust/pull/62610.