### PR TITLE
Add `Buffer::resize` and `Buffer::truncate`.

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -100,6 +100,8 @@ impl BufImpl {
 
         pub fn reserve(&mut self, additional: usize)[additional] -> bool;
 
+        pub fn resize(&mut self, new_len: usize, value: u8)[new_len, value] -> bool;
+
         pub fn make_room(&mut self)[];
 
         pub fn buf(&self)[] -> &[u8];
@@ -111,5 +113,7 @@ impl BufImpl {
         pub unsafe fn bytes_written(&mut self, add: usize)[add];
 
         pub fn consume(&mut self, amt: usize)[amt];
+
+        pub fn truncate(&mut self, len: usize)[len];
     }
 }

--- a/src/buffer/slice_deque_buf.rs
+++ b/src/buffer/slice_deque_buf.rs
@@ -48,6 +48,11 @@ impl SliceDequeBuf {
         true
     }
 
+    pub fn resize(&mut self, new_len: usize, value: u8) -> bool {
+        self.deque.resize(new_len, value);
+        true
+    }
+
     /// This method is a no-op.
     pub fn make_room(&mut self) {}
 
@@ -79,5 +84,9 @@ impl SliceDequeBuf {
 
             self.deque.move_head(offset);
         }
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        self.deque.truncate_back(len);
     }
 }


### PR DESCRIPTION
These methods enable users to use `Buffer` without having an intermediate array.

For example:

```
let mut buffer = Buffer::with_capacity(1024);
buffer.resize(1024, 0);
let len = fill_some_data(buffer.buf_mut());
buffer.truncate(len);
```