### PR TITLE
Pause of reading

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,9 +203,6 @@ pub struct BufReader<R, P = StdPolicy>{
     buf: Buffer,
     inner: R,
     policy: P,
-    // We need field "empty" to return empty &[u8] in case of reader is paused
-    // This field is never used, never filled.
-    empty: Vec<u8>,
 }
 
 impl<R> BufReader<R, StdPolicy> {
@@ -265,7 +262,7 @@ impl<R> BufReader<R, StdPolicy> {
     /// then it will be returned in `read()` and `fill_buf()` ahead of any data from `inner`.
     pub fn with_buffer(buf: Buffer, inner: R) -> Self {
         BufReader {
-            buf, inner, policy: StdPolicy, empty: vec![]
+            buf, inner, policy: StdPolicy
         }
     }
 }
@@ -276,7 +273,6 @@ impl<R, P> BufReader<R, P> {
         BufReader {
             inner: self.inner,
             buf: self.buf,
-            empty: self.empty,
             policy
         }
     }
@@ -386,7 +382,6 @@ impl<R: Read, P> BufReader<R, P> {
             inner,
             buf: self.buf,
             policy: self.policy,
-            empty: self.empty,
         }
     }
 }
@@ -413,7 +408,7 @@ impl<R: Read, P: ReaderPolicy> BufRead for BufReader<R, P> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         // If reading is paused, we are sending empty buffer to send signal - "no data any more"
         if self.is_paused() {
-            return Ok(&self.empty);
+            return Ok(&[][..]);
         }
         // If we've reached the end of our internal buffer then we need to fetch
         // some more data from the underlying reader.

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -64,6 +64,23 @@ pub trait ReaderPolicy {
     ///
     /// This is a no-op by default.
     fn after_consume(&mut self, _buffer: &mut Buffer, _amt: usize) {}
+
+    /// Consulted with `read` and `fill_buf` methods.
+    /// Return `bool` to continue (`true`) reading or pause it (`false`).
+    ///
+    /// ### Note
+    /// As soon as it was paused, the current position in the buffer isn't dropped.
+    /// The reader still can continue reading with the next iteration if the flag will
+    /// be changed again to `true`.
+    ///
+    /// Possible use-case. For example, we have a huge file, which we would like to
+    /// read and somehow manipulate with content (search in it for example). If we
+    /// are passing the reader into the searcher, we are losing control of it. Withing
+    /// `pausing` policy we can pass to a reader some kind of token and keep control
+    /// of the reading process.
+    fn is_paused(&mut self) -> bool {
+        false
+    }
 }
 
 /// Behavior of `std::io::BufReader`: the buffer will only be read into if it is empty.


### PR DESCRIPTION
These changes make it possible to pause/resume reading. It could be useful in case when we are passing a buffer reader forward and are losing control of it, but still, leave the possibility to pause of reading. For example, we have to read huge file and search inside of it. For search, we are using some kind of search and we are passing an instance of a reader into it. Well from that moment we can stop searching only if the searcher supports such kind of functionality, but if it doesn't - we cannot stop searching anyhow. With present changes, we can do it, even if we don't have direct access to the instance of reader.