### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/buffer/slice_deque_buf.rs
+++ b/src/buffer/slice_deque_buf.rs
@@ -70,12 +70,12 @@ impl SliceDequeBuf {
     }
 
     pub fn consume(&mut self, amt: usize) {
+        let offset = cmp::min(amt, self.len()) as isize;
+        if offset < 0 {
+            panic!("BufImpl.consume() arg overflowed isize: {:x}", amt)
+        }
         unsafe {
-            let offset = cmp::min(amt, self.len()) as isize;
 
-            if offset < 0 {
-                panic!("BufImpl.consume() arg overflowed isize: {:x}", amt)
-            }
 
             self.deque.move_head(offset);
         }

--- a/src/buffer/std_buf.rs
+++ b/src/buffer/std_buf.rs
@@ -148,8 +148,8 @@ mod impl_ {
 
             buf.reserve_exact(additional);
 
+            let new_cap = buf.capacity();
             unsafe {
-                let new_cap = buf.capacity();
                 buf.set_len(new_cap);
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1038,10 +1038,10 @@ impl Buffer {
 
         let cap = self.capacity();
         if self.zeroed < cap {
-            unsafe {
-                let buf = self.buf.write_buf();
+            
+                let buf = unsafe { self.buf.write_buf() };
                 init_buffer(&rdr, buf);
-            }
+            
 
             self.zeroed = cap;
         }
@@ -1064,8 +1064,8 @@ impl Buffer {
     /// it will fill the usable space and return the number of bytes copied. If there is no usable
     /// space, this returns 0.
     pub fn copy_from_slice(&mut self, src: &[u8]) -> usize {
-        let len = unsafe {
-            let mut buf = self.buf.write_buf();
+        let len = {
+            let mut buf = unsafe { self.buf.write_buf() };
             let len = cmp::min(buf.len(), src.len());
             buf[..len].copy_from_slice(&src[..len]);
             len


### PR DESCRIPTION
In these functions you use the unsafe keyword for some safe expressions. However, I found that only 3 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the write_buf()\set_len()\move_head() function(these are unsafe functions)

@abonander
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 