### PR TITLE
Remove trailing semicolon from `do_read` macro

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -22,7 +22,7 @@ pub struct DoRead(pub bool);
 /// Shorthand for `return DoRead(bool)` or `return DoRead(true)` (empty invocation)
 #[macro_export]
 macro_rules! do_read (
-    ($val:expr) => ( return $crate::policy::DoRead($val); );
+    ($val:expr) => ( return $crate::policy::DoRead($val) );
     () => ( do_read!(true); )
 );
 


### PR DESCRIPTION
Fixes #23

This will allow the macro to continue to be used in expression position (e.g. match arms), where semicolons are not allowed.